### PR TITLE
Refactor displayEndYear logic in polity_map.html

### DIFF
--- a/seshat/apps/core/templates/core/polity_map.html
+++ b/seshat/apps/core/templates/core/polity_map.html
@@ -168,14 +168,10 @@
                                 displayStartYear = shape.polityStartYear + ' CE';
                             }
 
-                            if (parseInt(shape.polityEndYear) == {{ content.latest_year }}){
-                                displayEndYear = 'Present';
+                            if (parseInt(shape.polityEndYear) < 0) {
+                                displayEndYear = Math.abs(parseInt(shape.polityEndYear)) + ' BCE';
                             } else {
-                                if (parseInt(shape.polityEndYear) < 0) {
-                                    displayEndYear = Math.abs(parseInt(shape.polityEndYear)) + ' BCE';
-                                } else {
-                                    displayEndYear = shape.polityEndYear + ' CE';
-                                }
+                                displayEndYear = shape.polityEndYear + ' CE';
                             }
 
                             // Add shape


### PR DESCRIPTION
The `if (parseInt(shape.polityEndYear) == {{ content.latest_year }}){` check only makes sense in the context of the world map, remove this logic from polity pages