### PR TITLE
Fix bug introduced by setting default display year on polity pages to the polity peak year start

### DIFF
--- a/seshat/apps/core/templatetags/core_tags.py
+++ b/seshat/apps/core/templatetags/core_tags.py
@@ -36,13 +36,18 @@ def polity_map(pk):
             i+=1
         content['capitals_info'] = modified_caps
         content['include_polity_map'] = True
-
-        # Set the default display year to be the peak year
-        peak_years = Polity_peak_years.objects.get(polity_id=page_id)
-        content['display_year'] = peak_years.peak_year_from
     except:
         content = {}
         content['include_polity_map'] = False
+
+    if content['include_polity_map']:
+        # Update the default display year to be the peak year (if it exists)
+        try:
+            peak_years = Polity_peak_years.objects.get(polity_id=page_id)
+            content['display_year'] = peak_years.peak_year_from
+        except:
+            pass
+    
     return {'content': content}
 
 def get_polity_capitals(pk):

--- a/seshat/apps/core/tests/tests.py
+++ b/seshat/apps/core/tests/tests.py
@@ -309,8 +309,8 @@ class ShapesTest(TestCase):
                         'geom': self.geo_square
                     }
                 ],
-                'earliest_year': 2000,  # This is the earliest year of the polity
-                'display_year': 2001,
+                'earliest_year': 2000,
+                'display_year': 2001,  # This is the peak year of the polity
                 'latest_year': 2020,
                 'seshat_id_page_id': {
                     'Test seshat_id': {'id': 1, 'long_name': 'TestPolity'}
@@ -322,6 +322,39 @@ class ShapesTest(TestCase):
             }
         }
         result = polity_map(self.pk)
+        self.assertEqual(result, expected_result)
+
+    def test_polity_map_no_peak_year_set(self):
+        """Test the polity_map template tag for a polity that has no peak year set."""
+        expected_result = {
+            'content': {
+                'shapes': [
+                    {
+                        'seshat_id': 'Test seshat_id 2',
+                        'name': 'Test shape 2',
+                        'start_year': 0,
+                        'end_year': 1000,
+                        'polity_start_year': 0,  # Note: this is taken from the shape objectm, not the polity object (they don't match in this test case)
+                        'polity_end_year': 1000,
+                        'colour': "#FFFFFF",
+                        'area': 100.0,
+                        'geom': self.geo_square
+                    }
+                ],
+                'earliest_year': 0,
+                'display_year': 0,
+                'latest_year': 1000,
+                'seshat_id_page_id': {
+                    'Test seshat_id 2': {'id': 2, 'long_name': 'TestPolity2'}
+                },
+                'include_polity_map': True,
+                'capitals_info': [
+                    {'capital': 'Test Capital 2A', 'latitude': 51.567523, 'longitude': -0.1294532, 'year_from': 0, 'year_to': 100},
+                    {'capital': 'Test Capital 2', 'latitude': 51.567523, 'longitude': -0.1294532, 'year_from': -100, 'year_to': 1100}
+                ]
+            }
+        }
+        result = polity_map(2)
         self.assertEqual(result, expected_result)
 
     def test_polity_map_no_content(self):


### PR DESCRIPTION
- Only set the display year to be peak year if one exists in the db
- Add a test case covering this update to `polity_map`