### PR TITLE
Update how GADM basemaps tables are handled

### DIFF
--- a/docs/spatialdb.md
+++ b/docs/spatialdb.md
@@ -28,33 +28,7 @@ To create a new shape dataset for use in the Seshat map explorer, you can do the
 ## GADM
 
 1. [Download](https://geodata.ucdavis.edu/gadm/gadm4.1/gadm_410-gpkg.zip) the whole world GeoPackage file from the [GADM website](https://gadm.org/download_world.html).
-2. Populate the `core_gadmshapefile` table
+2. Populate the `core_gadmshapefile`, `core_gadmcountries` and `core_gadmprovinces` tables
     ```
         python manage.py populate_gadm /path/to/gpkg_file
     ```
-3. To populate the `core_gadmcountries`, go into the database (`psql -U postgres -d <seshat_db_name>`) and run the following query:
-    ```{SQL}
-        INSERT INTO core_gadmcountries (geom, "COUNTRY")
-        SELECT 
-            COALESCE(ST_Simplify(ST_Union(geom), 0.01), ST_Simplify(ST_Union(geom), 0.001)) AS geom,
-            "COUNTRY"
-        FROM 
-            core_gadmshapefile
-        GROUP BY 
-            "COUNTRY";
-    ```
-4. To populate the `core_gadmprovinces`, go into the database (`psql -U postgres -d <seshat_db_name>`) and run the following query:
-    ```{SQL}
-        INSERT INTO core_gadmprovinces (geom, "COUNTRY", "NAME_1", "ENGTYPE_1")
-        SELECT 
-            COALESCE(ST_Simplify(ST_Union(geom), 0.01), ST_Simplify(ST_Union(geom), 0.001)) AS geom,
-            "COUNTRY",
-            "NAME_1",
-            "ENGTYPE_1"
-        FROM 
-            core_gadmshapefile
-        GROUP BY 
-            "COUNTRY", "NAME_1", "ENGTYPE_1";
-    ```
-
-The 0.01 value is the simplification tolerance. Using a lower value will increase the resolution of the shapes used, but result in slower loading in the django app. Some smaller countries/provinces cannot be simplified with 0.01, so try 0.001.

--- a/seshat/apps/core/management/commands/populate_gadm.py
+++ b/seshat/apps/core/management/commands/populate_gadm.py
@@ -82,9 +82,6 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Successfully populated the GADMShapefile table."))
 
-        # Close the connection to the GeoPackage file
-        data_source.close()
-
         # Populate the core_gadmcountries and core_gadmprovinces table
         # The 0.01 value is the simplification tolerance.
         # Using a lower value will increase the resolution of the shapes used, but result in slower loading in the django app.

--- a/seshat/apps/core/management/commands/populate_gadm.py
+++ b/seshat/apps/core/management/commands/populate_gadm.py
@@ -89,6 +89,7 @@ class Command(BaseCommand):
         # The 0.01 value is the simplification tolerance.
         # Using a lower value will increase the resolution of the shapes used, but result in slower loading in the django app.
         # Some smaller countries/provinces cannot be simplified with 0.01, so try 0.001.
+        self.stdout.write(self.style.SUCCESS(f"Populating the core_gadmcountries table..."))
         with connection.cursor() as cursor:
             cursor.execute("""
                 INSERT INTO core_gadmcountries (geom, "COUNTRY")
@@ -102,6 +103,7 @@ class Command(BaseCommand):
             """)
         self.stdout.write(self.style.SUCCESS(f"Successfully populated the core_gadmcountries table."))
 
+        self.stdout.write(self.style.SUCCESS(f"Populating the core_gadmprovinces table..."))
         with connection.cursor() as cursor:
             cursor.execute("""
                 INSERT INTO core_gadmprovinces (geom, "COUNTRY", "NAME_1", "ENGTYPE_1")

--- a/seshat/apps/core/management/commands/populate_gadm.py
+++ b/seshat/apps/core/management/commands/populate_gadm.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
             geom_gis = geom.geos
 
             # Create an entry in the GADMShapefile model for each feature in the layer
+            self.stdout.write(self.style.SUCCESS(f"Inserting features into the GADMShapefile table for feature UID: {feature.get('COUNTRY')}..."))
             GADMShapefile.objects.create(
                 geom=geom_gis,
                 UID=feature.get('UID'),

--- a/seshat/apps/core/management/commands/populate_gadm.py
+++ b/seshat/apps/core/management/commands/populate_gadm.py
@@ -1,7 +1,7 @@
 from django.db import connection
 from django.contrib.gis.gdal import DataSource
 from django.core.management.base import BaseCommand
-from seshat.apps.core.models import GADMShapefile
+from seshat.apps.core.models import GADMShapefile, GADMCountries, GADMProvinces
 
 class Command(BaseCommand):
     help = 'Populates the GADMShapefile table with features from a GeoPackage'
@@ -10,6 +10,19 @@ class Command(BaseCommand):
         parser.add_argument('gpkg_file', type=str, help='Path to the GeoPackage file')
 
     def handle(self, *args, **options):
+
+        # Clear the GADMShapefile table
+        self.stdout.write(self.style.SUCCESS('Clearing GADMShapefile table...'))
+        GADMShapefile.objects.all().delete()
+        self.stdout.write(self.style.SUCCESS('GADMShapefile table cleared'))
+        # Clear the core_gadmcountries table
+        self.stdout.write(self.style.SUCCESS('Clearing core_gadmcountries table...'))
+        GADMCountries.objects.all().delete()
+        self.stdout.write(self.style.SUCCESS('core_gadmcountries table cleared'))
+        # Clear the core_gadmprovinces table
+        self.stdout.write(self.style.SUCCESS('Clearing core_gadmprovinces table...'))
+        GADMProvinces.objects.all().delete()
+
         gpkg_file = options['gpkg_file']
 
         data_source = DataSource(gpkg_file)

--- a/seshat/apps/core/management/commands/populate_gadm.py
+++ b/seshat/apps/core/management/commands/populate_gadm.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             geom_gis = geom.geos
 
             # Create an entry in the GADMShapefile model for each feature in the layer
-            self.stdout.write(self.style.SUCCESS(f"Inserting features into the GADMShapefile table for feature UID: {feature.get('COUNTRY')}..."))
+            self.stdout.write(self.style.SUCCESS(f"Inserting features into the GADMShapefile table for {feature.get('COUNTRY')}..."))
             GADMShapefile.objects.create(
                 geom=geom_gis,
                 UID=feature.get('UID'),

--- a/seshat/apps/core/management/commands/populate_gadm.py
+++ b/seshat/apps/core/management/commands/populate_gadm.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.contrib.gis.gdal import DataSource
 from django.core.management.base import BaseCommand
 from seshat.apps.core.models import GADMShapefile
@@ -77,3 +78,40 @@ class Command(BaseCommand):
             )
 
             self.stdout.write(self.style.SUCCESS(f"Inserted feature into the GADMShapefile table."))
+
+        self.stdout.write(self.style.SUCCESS(f"Successfully populated the GADMShapefile table."))
+
+        # Close the connection to the GeoPackage file
+        data_source.close()
+
+        # Populate the core_gadmcountries and core_gadmprovinces table
+        # The 0.01 value is the simplification tolerance.
+        # Using a lower value will increase the resolution of the shapes used, but result in slower loading in the django app.
+        # Some smaller countries/provinces cannot be simplified with 0.01, so try 0.001.
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO core_gadmcountries (geom, "COUNTRY")
+                SELECT 
+                    COALESCE(ST_Simplify(ST_Union(geom), 0.01), ST_Simplify(ST_Union(geom), 0.001)) AS geom,
+                    "COUNTRY"
+                FROM 
+                    core_gadmshapefile
+                GROUP BY 
+                    "COUNTRY";
+            """)
+        self.stdout.write(self.style.SUCCESS(f"Successfully populated the core_gadmcountries table."))
+
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO core_gadmprovinces (geom, "COUNTRY", "NAME_1", "ENGTYPE_1")
+                SELECT 
+                    COALESCE(ST_Simplify(ST_Union(geom), 0.01), ST_Simplify(ST_Union(geom), 0.001)) AS geom,
+                    "COUNTRY",
+                    "NAME_1",
+                    "ENGTYPE_1"
+                FROM 
+                    core_gadmshapefile
+                GROUP BY 
+                    "COUNTRY", "NAME_1", "ENGTYPE_1";
+            """)
+        self.stdout.write(self.style.SUCCESS(f"Successfully populated the core_gadmprovinces table."))

--- a/seshat/apps/core/static/core/js/map_functions.js
+++ b/seshat/apps/core/static/core/js/map_functions.js
@@ -118,33 +118,35 @@ function switchBaseMap() {
                         return [coord[1], coord[0]];
                     });
                     var polygon = L.polygon(coordinates).addTo(map);
-                    if (base == 'province') {
-                        var popupContent = `
-                            <table>
-                                <tr>
-                                    <th>${shape.province}</th>
-                                    <th></th>
-                                </tr>
-                                <tr>
-                                    <td>Type</td>
-                                    <td>${shape.provinceType}</td>
-                                </tr>
-                                <tr>
-                                    <td>Country</td>
-                                    <td>Modern ${shape.country}</td>
-                                </tr>
-                            </table>
-                        `;
-                    } else if (base == 'country') {
-                        var popupContent = `
-                            <table>
-                                <tr>
-                                    <th>Modern ${shape.country}</td>
-                                </tr>
-                            </table>
-                        `;
-                    }
-                    polygon.bindPopup(popupContent);
+                    if (!shape.country.toLowerCase().includes('sea')) {
+                        if (base == 'province') {
+                            var popupContent = `
+                                <table>
+                                    <tr>
+                                        <th>${shape.province}</th>
+                                        <th></th>
+                                    </tr>
+                                    <tr>
+                                        <td>Type</td>
+                                        <td>${shape.provinceType}</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Country</td>
+                                        <td>Modern ${shape.country}</td>
+                                    </tr>
+                                </table>
+                            `;
+                        } else if (base == 'country') {
+                            var popupContent = `
+                                <table>
+                                    <tr>
+                                        <th>Modern ${shape.country}</td>
+                                    </tr>
+                                </table>
+                            `;
+                        }
+                        polygon.bindPopup(popupContent);
+                    };               
                     // Set the style using the style method
                     polygon.setStyle({
                         fillColor: gadmFillColour,   // Set the fill color based on the "colour" field

--- a/seshat/apps/core/static/core/js/map_functions.js
+++ b/seshat/apps/core/static/core/js/map_functions.js
@@ -106,6 +106,10 @@ function switchBaseMap() {
         baseShapeData.forEach(function (shape) {
             // Ensure the geometry is not empty
             if (shape.geometry && shape.geometry.type) {
+                gadmFillColour = 'white';  // Default fill colour
+                if (shape.country.toLowerCase().includes('sea')) {
+                    gadmFillColour = 'lightblue';
+                }
                 // Loop through each polygon and add it to the map
                 for (var i = 0; i < shape.geometry.coordinates.length; i++) {
                     var coordinates = shape.geometry.coordinates[i][0];
@@ -143,7 +147,7 @@ function switchBaseMap() {
                     polygon.bindPopup(popupContent);
                     // Set the style using the style method
                     polygon.setStyle({
-                        fillColor: 'white',   // Set the fill color based on the "colour" field
+                        fillColor: gadmFillColour,   // Set the fill color based on the "colour" field
                         color: 'black',       // Set the border color
                         weight: 1,            // Set the border weight
                         fillOpacity: 1        // Set the fill opacity

--- a/seshat/apps/core/static/core/js/map_functions.js
+++ b/seshat/apps/core/static/core/js/map_functions.js
@@ -106,7 +106,7 @@ function switchBaseMap() {
         baseShapeData.forEach(function (shape) {
             // Ensure the geometry is not empty
             if (shape.geometry && shape.geometry.type) {
-                gadmFillColour = 'white';  // Default fill colour
+                gadmFillColour = 'none';  // Default fill colour
                 if (shape.country.toLowerCase().includes('sea')) {
                     gadmFillColour = 'lightblue';
                 }


### PR DESCRIPTION
- [x] Update the populate_gadm script so it runs the last SQL steps currently in spatialdb docs
    - [x] Could also make the printout a bit more informative
- [x] In GADM, set the colour of "Modern Caspian Sea" to blue and don't add "Modern". Do this for all seas.
- [x] Try the GADM basemap with a clear fill instead of white